### PR TITLE
Add main definition to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "angular-pull-to-refresh",
   "version": "0.3.0",
   "description": "angular-pull-to-refresh",
+  "main": "dist/angular-pull-to-refresh.js",
   "keywords": [
     "angular"
   ],


### PR DESCRIPTION
Add main definition, so that bower-concat knows which file to concatenate. Otherwise special setup is required. See https://github.com/sapegin/grunt-bower-concat, chapter "mainFiles"
